### PR TITLE
Add ActiveCampaign demo

### DIFF
--- a/activecampaign-to-postgres/README.md
+++ b/activecampaign-to-postgres/README.md
@@ -1,0 +1,27 @@
+# ActiveCampaign to Postgres with dlt
+
+This example shows how to load data from the ActiveCampaign REST API into a PostgreSQL database using [dlt](https://github.com/dlt-hub/dlt).
+
+## Prerequisites
+
+- Python 3.10+
+- Access to an ActiveCampaign account
+- A Postgres database
+
+Create a `.dlt/secrets.toml` file or export the following environment variables:
+
+```
+ACTIVE_CAMPAIGN_BASE_URL=<https://YOUR_ACCOUNT.api-us1.com>
+ACTIVE_CAMPAIGN_API_KEY=<your api key>
+```
+
+The Postgres connection settings can also be provided via `secrets.toml`.
+
+Install the requirements and run the pipeline:
+
+```bash
+pip install -r requirements.txt
+python activecampaign_pipeline.py
+```
+
+The pipeline will fetch contacts from ActiveCampaign and store them in a table named `contacts` under the dataset `activecampaign_data`.

--- a/activecampaign-to-postgres/activecampaign_pipeline.py
+++ b/activecampaign-to-postgres/activecampaign_pipeline.py
@@ -1,0 +1,42 @@
+import os
+import dlt
+import requests
+
+API_BASE = os.environ.get("ACTIVE_CAMPAIGN_BASE_URL")
+API_KEY = os.environ.get("ACTIVE_CAMPAIGN_API_KEY")
+
+headers = {"Api-Token": API_KEY}
+
+@dlt.resource(write_disposition="replace")
+def contacts(limit: int = 100):
+    offset = 0
+    while True:
+        params = {"limit": limit, "offset": offset}
+        resp = requests.get(f"{API_BASE}/api/3/contacts", params=params, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        items = data.get("contacts") or data.get("data") or []
+        if not items:
+            break
+        for contact in items:
+            yield contact
+        offset += limit
+
+@dlt.source
+def activecampaign_source():
+    yield contacts()
+
+
+def run_pipeline() -> None:
+    pipeline = dlt.pipeline(
+        pipeline_name="activecampaign_pipeline",
+        destination="postgres",
+        dataset_name="activecampaign_data",
+        full_refresh=True,
+    )
+    load_info = pipeline.run(activecampaign_source())
+    print(load_info)
+
+
+if __name__ == "__main__":
+    run_pipeline()

--- a/activecampaign-to-postgres/requirements.txt
+++ b/activecampaign-to-postgres/requirements.txt
@@ -1,0 +1,2 @@
+dlt
+requests


### PR DESCRIPTION
## Summary
- create ActiveCampaign pipeline demo loading contacts to Postgres
- document required environment variables
- add example requirements file

## Testing
- `python -m py_compile activecampaign-to-postgres/activecampaign_pipeline.py`
- `python activecampaign-to-postgres/activecampaign_pipeline.py` *(fails: Invalid URL 'None/api/3/contacts')*

------
https://chatgpt.com/codex/tasks/task_b_686517a921fc8327ae298dd5a57250dd